### PR TITLE
Allow animations with Oids

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ pg_lock_tracer -x /home/jan/postgresql-sandbox/bin/REL_15_1_DEBUG/bin/postgres -
 # Show statistics about locks
 pg_lock_tracer -x /home/jan/postgresql-sandbox/bin/REL_15_1_DEBUG/bin/postgres -p 1234 --statistics
 
-# Create an animated lock graph
-animate_lock_graph -i create_table_trace.json -o create_table_trace.html
+# Create an animated lock graph (with Oids)
+pg_lock_tracer -x /home/jan/postgresql-sandbox/bin/REL_15_1_DEBUG/bin/postgres -p 1234 -j -o locks.json
+animate_lock_graph -i lock -o locks.html
+
+# Create an animated lock graph (with table names)
+pg_lock_tracer -x /home/jan/postgresql-sandbox/bin/REL_15_1_DEBUG/bin/postgres -p 1234 -j -r 1234:psql://jan@localhost/test2 -o locks.json
+animate_lock_graph -i lock -o locks.html
 ```
 
 ## Example Output

--- a/src/pg_lock_tracer/animate_lock_graph.py
+++ b/src/pg_lock_tracer/animate_lock_graph.py
@@ -207,7 +207,7 @@ class DOTModel:
             if self.verbose:
                 print(f"Processing {event}")
 
-            tablename = event["table"]
+            tablename = StringHelper.get_tablename(event)
             lock_type = event["lock_type"]
 
             if not self.graph.vs.select(label_eq=tablename):
@@ -244,7 +244,7 @@ class DOTModel:
             if self.verbose:
                 print(f"Processing {event}")
 
-            tablename = event["table"]
+            tablename = StringHelper.get_tablename(event)
             lock_type = event["lock_type"]
             lock_numeric_value = PostgreSQLLockHelper.lock_type_to_int(lock_type)
 
@@ -382,6 +382,16 @@ class StringHelper:
                 result += "\\n"
 
         return result
+
+    @staticmethod
+    def get_tablename(event):
+        """
+        Get the tablename or the Oid of the event.
+        """
+        if "table" in event:
+            return event["table"]
+
+        return f"Oid {event['oid']}"
 
 
 def main():


### PR DESCRIPTION
So far, animations could be only generated if the Oids of the table names were resolved to actual table names. This patch removes this limitation and also allows animations using OIDs.