### PR TITLE
Redirect stacktraces to file if needed

### DIFF
--- a/src/pg_lock_tracer/pg_lock_tracer.py
+++ b/src/pg_lock_tracer/pg_lock_tracer.py
@@ -470,7 +470,8 @@ class PGLockTraceOutputHuman(PGLockTraceOutput):
                 )
                 line = line.decode("utf-8")
                 # Get line with: 'gdb info line *(symbol+0x1111)'
-                print(f"\t{line}")
+                line = f"\t{line}"
+                self.handle_output_line(line)
 
 
 class PGLockTraceOutputJSON(PGLockTraceOutput):


### PR DESCRIPTION
So far, the output file was ignored when stack traces are printed. This PR fixes the behavior.