### PR TITLE
avoid a hanging transaction from oid_resolver

### DIFF
--- a/src/pg_lock_tracer/oid_resolver.py
+++ b/src/pg_lock_tracer/oid_resolver.py
@@ -34,7 +34,7 @@ class OIDResolver:
                 host=hostname,
                 port=port,
             )
-
+            self.connection.set_session(autocommit=True)
             self.cur = self.connection.cursor()
 
             # Warmup cache


### PR DESCRIPTION
I noticed that OID resolver leaves a hanging transaction after the initial select because it uses psycopg2 with autocommit=off, so every statement has to be explicitly committed or will stay idle in transaction after running. I suggest to set the autocommit to true, that way every select is executed in its own transaction.